### PR TITLE
Update pip and stick to IPython 5 for py27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get -y install \
     ipython \
     python-zmq \
     python-jinja2
+RUN pip install --upgrade pip
 RUN pip install voevent-parse
 RUN pip install comet
 RUN pip install ipython --upgrade
@@ -24,5 +25,5 @@ RUN pip install jupyter
 RUN pip install tornado --upgrade
 RUN pip install jsonschema
 WORKDIR /ipynb
-CMD jupyter notebook --no-browser --ip=0.0.0.0
+CMD jupyter notebook --no-browser --ip=0.0.0.0 --allow-root
 EXPOSE 8888

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-###IPython notebook running in specific environment
+### IPython notebook running in specific environment
 
-###To use do the following in directory with Dockerfile:
+### To use do the following in directory with Dockerfile:
 
 ```
 docker build -t notebook .


### PR DESCRIPTION
I got some errors when trying to build the Docker image today.
- IPython 6.0+ does not support Python 2.7, so we need to stick to version 5.x.  By installing a newer pip (9.0.1 at the moment), it automatically uses the correct version of IPython.
- When starting the Docker image, jupyter complained that the `--allow-root` option must be specified, otherwise it aborts.

Minor markup fix in readme to get proper headings.